### PR TITLE
Support for remote db host and passwords with special characters

### DIFF
--- a/syncCraft.cfg
+++ b/syncCraft.cfg
@@ -2,6 +2,8 @@
 # ---------------
 
 # Remote database name
+remote_db_host=
+# Remote database name
 remote_db_name=
 # Remote database username
 remote_db_username=

--- a/syncCraft.cfg
+++ b/syncCraft.cfg
@@ -7,7 +7,7 @@ remote_db_host=
 remote_db_name=
 # Remote database username
 remote_db_username=
-# Remote database password
+# Remote database password (passwords containing special characters * ? [ < > & ; ! | $ ( ) should be double-quoted, e.g "pAsS>0rd")
 remote_db_password=
 # SSH string to connect to your remote server (e.g. 'myuser@myhost.com')
 ssh_string=

--- a/syncCraft.cfg
+++ b/syncCraft.cfg
@@ -1,7 +1,7 @@
 # REMOTE SETTINGS
 # ---------------
 
-# Remote database name
+# Remote database host (will default to 'localhost')
 remote_db_host=
 # Remote database name
 remote_db_name=

--- a/syncCraft.sample.cfg
+++ b/syncCraft.sample.cfg
@@ -1,6 +1,8 @@
 # REMOTE SETTINGS
 # ---------------
 
+# Remote database host (will default to 'localhost')
+remote_db_name=mysql.mattstauffer.co
 # Remote database name
 remote_db_name=mattstauffer_co
 # Remote database username

--- a/syncCraft.sample.cfg
+++ b/syncCraft.sample.cfg
@@ -7,7 +7,7 @@ remote_db_name=mysql.mattstauffer.co
 remote_db_name=mattstauffer_co
 # Remote database username
 remote_db_username=mattstaufferSqlUser
-# Remote database password
+# Remote database password (passwords containing special characters * ? [ < > & ; ! | $ ( ) should be double-quoted, e.g "pAsS>0rd")
 remote_db_password=mySuperSecretPassword
 # SSH string to connect to your remote server (e.g. 'myuser@myhost.com')
 ssh_string=matt@141.24.1.4

--- a/syncCraft.sh
+++ b/syncCraft.sh
@@ -21,13 +21,14 @@ fi
 
 # Set defaults
 : ${mysql_path:='mysql'}
+: ${remote_db_host:='localhost'}
 : ${local_db_username:='root'}
 : ${local_db_password:='root'}
 
 # Sync database and import
 echo -e "\nSyncing database down...\n"
 
-ssh $ssh_string "mysqldump $remote_db_name --quote-names --opt --hex-blob --add-drop-database -u$remote_db_username -p$remote_db_password" | $mysql_path -D$local_db_name -u$local_db_username -p$local_db_password
+ssh $ssh_string "mysqldump $remote_db_name --quote-names --opt --hex-blob --add-drop-database -h$remote_db_host -u$remote_db_username -p$remote_db_password" | $mysql_path -D$local_db_name -u$local_db_username -p$local_db_password
 echo -e "Database synced and imported.\n"
 
 # Sync assets

--- a/syncCraft.sh
+++ b/syncCraft.sh
@@ -28,7 +28,7 @@ fi
 # Sync database and import
 echo -e "\nSyncing database down...\n"
 
-ssh $ssh_string "mysqldump $remote_db_name --quote-names --opt --hex-blob --add-drop-database -h$remote_db_host -u$remote_db_username -p$remote_db_password" | $mysql_path -D$local_db_name -u$local_db_username -p$local_db_password
+ssh $ssh_string "mysqldump $remote_db_name --quote-names --opt --hex-blob --add-drop-database -h$remote_db_host -u$remote_db_username -p\"$remote_db_password\"" | $mysql_path -D$local_db_name -u$local_db_username -p$local_db_password
 echo -e "Database synced and imported.\n"
 
 # Sync assets


### PR DESCRIPTION
# Support for remote db host

Added support for `remote_db_host` value other than `localhost` through a new variable named `remote_db_host`. It defaults to `localhost`, so there should be no change in settings for people who don't need it.
# Support for db passwords containing special characters

Added double quotes around the password in the `mysqldump` command so passwords with special characters (`* ? [ < > & ; ! | $ ( )`) be be used. When remote_db_password has special characters, the value should be set using double-quotes (`remote_db_password="pAsS>0rd"`), passwords with normal characters are added the same as before (`remote_db_password=mySuperSecretPassword`)
